### PR TITLE
Publish to VSCode/VSCodium extension registries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,3 +51,9 @@ jobs:
       with:
         name: artifacts-view-avalonia-preview-vscode
         path: ./*.vsix
+
+    - name: Publish to Open VSX Registry
+      uses: HaaLeo/publish-vscode-extension@v1
+      with:
+        extensionFile: ./*.vsix
+        pat: ${{ secrets.OPEN_VSX_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,3 +57,10 @@ jobs:
       with:
         extensionFile: ./*.vsix
         pat: ${{ secrets.OPEN_VSX_TOKEN }}
+        
+    - name: Publish to Visual Studio Marketplace
+      uses: HaaLeo/publish-vscode-extension@v1
+      with:
+        extensionFile: ./*.vsix
+        pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+        registryUrl: https://marketplace.visualstudio.com


### PR DESCRIPTION
This will make the extension more discoverable and more easily accessible to users.

Currently, I only know of the Microsoft's [Visual Studio Marketplace](https://marketplace.visualstudio.com/vscode) and Eclipse Foundation's [Open VSX Registry](https://open-vsx.org/). The latter is the default registry for VSCodium (The FLOSS-licensed builds of VSCode), but it [may be decommissioned at the end of May](https://blogs.eclipse.org/post/john-kellerman/help-us-sustain-open-vsxorg) so publishing to Open VSX is up to your discretion.

If publishing to one or the other is undesired, feel free to drop the corresponding commit.
If not intended for use in  Production, the extension can be marked as a prerelease by modifying the `version` property in package.json. <details><summary><h4>"prerelease" rules and examples from semver.org</h4></summary>

> 4. Precedence for two pre-release versions with the same major, minor, and patch version MUST be determined by comparing each dot separated identifier from left to right until a difference is found as follows:
>    1. Identifiers consisting of only digits are compared numerically.
>    2. Identifiers with letters or hyphens are compared lexically in ASCII sort order.
>    3. Numeric identifiers always have lower precedence than non-numeric identifiers.
>    4. A larger set of pre-release fields has a higher precedence than a smaller set, if all of the preceding identifiers are equal.
> Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
</details>

Both platforms require prior setup before view-avalonia-preview can be published to them. Most importantly, both require access tokens for authorization. These token need to be accessible to [HaaLeo/publish-vscode-extension](https://github.com/marketplace/actions/publish-vs-code-extension) as workplace secrets (`OPEN_VSX_TOKEN`, `VS_MARKETPLACE_TOKEN`).
- [Open VSX Registry](https://github.com/marketplace/actions/publish-vs-code-extension#open-vsx-registry)
	- [ ] [Create an access token](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions#3-create-an-access-token)
		- [ ] [Log in and sign the Publisher Agreement](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions#2-log-in-and-sign-the-publisher-agreement)
			- [ ] [Create an Eclipse account](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions#1-create-an-eclipse-account)
	- [x] Package LICENSE file
	- [ ] [Create a namespace/publisher](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions#4-create-the-namespace).
	- [ ] [Add access token to GitHub repository's Secrets.](https://github.com/rstm-sf/view-avalonia-preview-vscode/settings/secrets/actions/new) Name it `OPEN_VSX_TOKEN`.
- [Visual Studio Marketplace](https://github.com/marketplace/actions/publish-vs-code-extension#visual-studio-marketplace)
	- [ ] [Create an access token](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token)
		- [ ] [Create organization in Azure DevOps](https://learn.microsoft.com/azure/devops/organizations/accounts/create-organization)
	- [ ] [Create a publisher](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#create-a-publisher)
 	- [ ] [Add access token to GitHub repository's Secrets.](https://github.com/rstm-sf/view-avalonia-preview-vscode/settings/secrets/actions/new) Name it `VS_MARKETPLACE_TOKEN`.